### PR TITLE
chore: update Docker build workflow to use GitHub Container Registry

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,11 +20,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Log in to Docker Hub
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -33,5 +34,5 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            firzus/portfolio-website:latest
+            ghcr.io/${{ github.repository_owner }}/portfolio-website:latest
           platforms: linux/amd64


### PR DESCRIPTION
- Changed the Docker login step to authenticate with GitHub Container Registry instead of Docker Hub.
- Updated the image tag format to reflect the new registry path for the Docker image.