### PR TITLE
feat: externalise contact email into environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_SITE_URL=https://example.com
 RESEND_API_KEY=re_your_resend_api_key
+CONTACT_EMAIL=your-email@example.com

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,6 +1,9 @@
 import { Resend } from 'resend'
 import { z } from 'zod'
 
+// Content / Data / Components
+import { env } from '@/env'
+
 const contactSchema = z.object({
   name: z.string().min(1),
   email: z.string().email(),
@@ -21,7 +24,7 @@ export async function POST(request: Request) {
 
   const { error } = await resend.emails.send({
     from: 'Lilian Music <contact@portfolio.lprieu.dev>',
-    to: ['contact.lprieu@gmail.com'],
+    to: [env.CONTACT_EMAIL],
     subject: `New message from ${name}`,
     replyTo: email,
     html: `

--- a/env.ts
+++ b/env.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 const envSchema = z.object({
   NEXT_PUBLIC_SITE_URL: z.url(),
+  CONTACT_EMAIL: z.string().email(),
 })
 
 type Env = z.infer<typeof envSchema>
@@ -13,6 +14,7 @@ export const env: Env = new Proxy({} as Env, {
     if (!_env) {
       _env = envSchema.parse({
         NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+        CONTACT_EMAIL: process.env.CONTACT_EMAIL,
       })
     }
     return _env[key as keyof Env]


### PR DESCRIPTION
## Summary

- Remplace l'adresse email de destination Resend codée en dur par une variable d'environnement `CONTACT_EMAIL`
- Ajoute la validation Zod de `CONTACT_EMAIL` dans `env.ts`
- Met à jour `.env.example` avec le nouveau placeholder

## Test plan

- [ ] Vérifier que la variable `CONTACT_EMAIL` est bien définie dans `.env` (et sur l'hébergeur)
- [ ] Soumettre le formulaire de contact et vérifier que le mail arrive à la bonne adresse
- [ ] Vérifier que le build échoue si `CONTACT_EMAIL` est absente ou invalide (validation Zod)